### PR TITLE
Add generation rules and command flags

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/nodonoghue/ppm/internal/cli"
@@ -14,23 +19,40 @@ func main() {
 	commandFlags := cli.GetFlags()
 	flag.Parse()
 
-	fmt.Println("Generating 10 AllChars Password Examples:")
+	fmt.Printf("Generating %d AllChars Password Examples:\n", *commandFlags.NumVariants)
 	fmt.Println("-----------------------------------------")
 
-	ch := make(chan string, *commandFlags.Options)
+	ch := make(chan string, *commandFlags.NumVariants)
 
 	//generate 10 options
 	var wg sync.WaitGroup
-	for i := 0; i < *commandFlags.Options; i++ {
+	for i := 0; i < *commandFlags.NumVariants; i++ {
 		wg.Add(1)
-		go generate.Password(ch, &wg)
+		go generate.Password(ch, &wg, commandFlags)
 	}
 	wg.Wait()
 	close(ch)
 
 	optionNum := 1
+	variants := make(map[int]string)
 	for password := range ch {
 		fmt.Printf("Option %d: %s\n", optionNum, password)
+		variants[optionNum-1] = password
 		optionNum++
 	}
+
+	fmt.Println("Select an Option to copy to the clipboard")
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal("Unable to read input")
+	}
+	num, err := strconv.Atoi(strings.Replace(input, "\n", "", -1))
+	if err != nil {
+		log.Fatal("Input must be numeric. ", err.Error())
+	}
+
+	selected := variants[num-1]
+
+	fmt.Printf("You have selected: %s\n", selected)
 }

--- a/src/internal/cli/flags.go
+++ b/src/internal/cli/flags.go
@@ -8,11 +8,36 @@ import (
 
 func GetFlags() models.CommandFlags {
 	var commandFlags models.CommandFlags
-	commandFlags.Options = setNumOptsLong()
+	commandFlags.NumVariants = setNumVariants()
+	commandFlags.Length = setPasswordLength()
+	commandFlags.NumLowerCase = setNumLowerCase()
+	commandFlags.NumUpperCase = setNumUpperCase()
+	commandFlags.NumNumbers = setNumNumbers()
+	commandFlags.NumSpecial = setNumSpecial()
 	flag.Parse()
 	return commandFlags
 }
 
-func setNumOptsLong() *int {
-	return flag.Int("o", 1, "Sets the number of password options to generate")
+func setNumVariants() *int {
+	return flag.Int("v", 1, "Sets the number of password variants to generate")
+}
+
+func setPasswordLength() *int {
+	return flag.Int("length", 8, "Sets the password length, must be at least 8 chars long")
+}
+
+func setNumUpperCase() *int {
+	return flag.Int("u", 1, "Sets the number of upper case chars in each variant")
+}
+
+func setNumLowerCase() *int {
+	return flag.Int("l", 1, "Sets the number of lower case chars in each variant.  Will be overwritten if the sum of all char settings is less than 8 to ensure the password length is at least 8 chars.")
+}
+
+func setNumNumbers() *int {
+	return flag.Int("n", 1, "Sets the number of number chars in each variant")
+}
+
+func setNumSpecial() *int {
+	return flag.Int("s", 0, "Sets the number of special ( ! @ # $ % ^ & * ) chars in each variant")
 }

--- a/src/internal/generate/generate.go
+++ b/src/internal/generate/generate.go
@@ -2,20 +2,86 @@ package generate
 
 import (
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/nodonoghue/ppm/internal/models"
 )
 
-func Password(ch chan<- string, wg *sync.WaitGroup) {
+func Password(ch chan<- string, wg *sync.WaitGroup, configuration models.CommandFlags) {
 	defer wg.Done()
 	rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	//use shuffle to create a len20 password and print to terminal:
-	buf := make([]byte, models.Length)
-	for i := 0; i < models.Length; i++ {
-		buf[i] = models.AllChars[rand.Intn(len(models.AllChars))]
+	// //use shuffle to create a len20 password and print to terminal:
+	// buf := make([]byte, models.Length)
+	// for i := 0; i < models.Length; i++ {
+	// 	buf[i] = models.AllChars[rand.Intn(len(models.AllChars))]
+	// }
+
+	var builder strings.Builder
+
+	if *configuration.NumUpperCase > 0 {
+		builder.Write([]byte(getUpperChars(*configuration.NumUpperCase)))
 	}
-	ch <- string(buf)
+	if *configuration.NumNumbers > 0 {
+		builder.Write([]byte(getNumberChars(*configuration.NumNumbers)))
+	}
+	if *configuration.NumSpecial > 0 {
+		builder.Write([]byte(getSpecialChars(*configuration.NumSpecial)))
+	}
+
+	numLower := getNumLower(configuration)
+	if numLower > 0 {
+		builder.Write([]byte(getLowerChars(numLower)))
+	}
+
+	ch <- shuffleChars(strings.Split(builder.String(), ""))
+}
+
+func getUpperChars(numUpper int) string {
+	buf := make([]byte, numUpper)
+	for i := 0; i < numUpper; i++ {
+		buf[i] = models.UpperCase[rand.Intn(len(models.UpperCase))]
+	}
+	return string(buf)
+}
+
+func getNumberChars(numNumbers int) string {
+	buf := make([]byte, numNumbers)
+	for i := 0; i < numNumbers; i++ {
+		buf[i] = models.Numbers[rand.Intn(len(models.Numbers))]
+	}
+	return string(buf)
+}
+
+func getSpecialChars(numSpecialChars int) string {
+	buf := make([]byte, numSpecialChars)
+	for i := 0; i < numSpecialChars; i++ {
+		buf[i] = models.SpecialChars[rand.Intn(len(models.SpecialChars))]
+	}
+	return string(buf)
+}
+
+func getLowerChars(numLower int) string {
+	buf := make([]byte, numLower)
+	for i := 0; i < numLower; i++ {
+		buf[i] = models.LowerCase[rand.Intn(len(models.LowerCase))]
+	}
+	return string(buf)
+}
+
+func shuffleChars(chars []string) string {
+	rand.Shuffle(len(chars), func(i, j int) {
+		chars[i], chars[j] = chars[j], chars[i]
+	})
+	return strings.Join(chars, "")
+}
+
+func getNumLower(configuration models.CommandFlags) int {
+	//sum  up all parts to determine the leftover, this leftover will be the number of lowercase
+	if (*configuration.NumUpperCase + *configuration.NumNumbers + *configuration.NumSpecial) < *configuration.Length {
+		return *configuration.Length - (*configuration.NumUpperCase + *configuration.NumNumbers + *configuration.NumSpecial)
+	}
+	return 0
 }

--- a/src/internal/models/customerrors.go
+++ b/src/internal/models/customerrors.go
@@ -1,0 +1,11 @@
+package models
+
+type GenerationError struct {
+	Message       string
+	FunctionName  string
+	Configuration CommandFlags
+}
+
+func (generationError *GenerationError) Error() string {
+	return generationError.Message
+}

--- a/src/internal/models/models.go
+++ b/src/internal/models/models.go
@@ -1,5 +1,11 @@
 package models
 
 type CommandFlags struct {
-	Options *int
+	NumVariants  *int
+	Length       *int
+	NumUpperCase *int
+	NumLowerCase *int
+	NumNumbers   *int
+	NumSpecial   *int
+	IsHelp       *bool
 }


### PR DESCRIPTION
Can now set how many upper case chars, number chars, and special chars to generate a password with.  Can also set the length, if length is longer than the combined sum of upper, numbers, and special chars lower case chars will fill in the rest.